### PR TITLE
Fix: define impl_json_display and impl_json_debug_pretty macros locally

### DIFF
--- a/src/config/base.rs
+++ b/src/config/base.rs
@@ -12,7 +12,6 @@ use crate::constants::{
     DEFAULT_TEST_PORT,
 };
 use crate::error::{DeribitFixError, Result};
-use deribit_base::{impl_json_debug_pretty, impl_json_display};
 use dotenv::dotenv;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,6 +238,9 @@
 //! Trading financial instruments carries risk - use at your own discretion.
 //!
 
+#[macro_use]
+mod macros;
+
 pub mod client;
 pub mod config;
 pub mod connection;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,31 @@
+/// Implements `std::fmt::Display` for one or more types using JSON serialization.
+macro_rules! impl_json_display {
+    ($($t:ty),+ $(,)?) => {
+        $(
+            impl std::fmt::Display for $t {
+                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    match serde_json::to_string(self) {
+                        Ok(s) => write!(f, "{}", s),
+                        Err(e) => write!(f, "{{\"error\": \"{}\"}}", e),
+                    }
+                }
+            }
+        )+
+    };
+}
+
+/// Implements `std::fmt::Debug` for one or more types using pretty-printed JSON serialization.
+macro_rules! impl_json_debug_pretty {
+    ($($t:ty),+ $(,)?) => {
+        $(
+            impl std::fmt::Debug for $t {
+                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    match serde_json::to_string_pretty(self) {
+                        Ok(s) => write!(f, "{}", s),
+                        Err(e) => write!(f, "{{\"error\": \"{}\"}}", e),
+                    }
+                }
+            }
+        )+
+    };
+}

--- a/src/message/admin.rs
+++ b/src/message/admin.rs
@@ -17,7 +17,6 @@ use crate::message::MessageBuilder;
 use crate::model::message::FixMessage;
 use crate::model::types::MsgType;
 use chrono::Utc;
-use deribit_base::impl_json_display;
 use serde::{Deserialize, Serialize};
 
 /// Heartbeat message (MsgType = 0)

--- a/src/message/orders/cancel_reject.rs
+++ b/src/message/orders/cancel_reject.rs
@@ -11,7 +11,6 @@ use crate::error::Result as DeribitFixResult;
 use crate::message::builder::MessageBuilder;
 use crate::model::types::MsgType;
 use chrono::{DateTime, Utc};
-use deribit_base::{impl_json_debug_pretty, impl_json_display};
 use serde::{Deserialize, Serialize};
 
 /// Order Cancel Reject message (MsgType = '9')

--- a/src/message/orders/cancel_replace_request.rs
+++ b/src/message/orders/cancel_replace_request.rs
@@ -11,7 +11,6 @@ use crate::error::Result as DeribitFixResult;
 use crate::message::builder::MessageBuilder;
 use crate::model::types::MsgType;
 use chrono::{DateTime, Utc};
-use deribit_base::{impl_json_debug_pretty, impl_json_display};
 use serde::{Deserialize, Serialize};
 
 /// Order Cancel/Replace Request message (MsgType = 'G')

--- a/src/message/orders/cancel_request.rs
+++ b/src/message/orders/cancel_request.rs
@@ -9,7 +9,6 @@
 use crate::error::{DeribitFixError, Result as DeribitFixResult};
 use crate::{message::builder::MessageBuilder, model::types::MsgType};
 use chrono::Utc;
-use deribit_base::{impl_json_debug_pretty, impl_json_display};
 use serde::{Deserialize, Serialize};
 
 /// Order Cancel Request message (MsgType = 'F')

--- a/src/message/orders/execution_report.rs
+++ b/src/message/orders/execution_report.rs
@@ -11,7 +11,6 @@ use crate::error::Result as DeribitFixResult;
 use crate::message::builder::MessageBuilder;
 use crate::model::types::{ExecType, MsgType};
 use chrono::{DateTime, Utc};
-use deribit_base::{impl_json_debug_pretty, impl_json_display};
 use serde::{Deserialize, Serialize};
 
 /// Execution Report message (MsgType = '8')

--- a/src/message/orders/mass_cancel.rs
+++ b/src/message/orders/mass_cancel.rs
@@ -11,7 +11,6 @@ use crate::error::{DeribitFixError, Result as DeribitFixResult};
 use crate::message::builder::MessageBuilder;
 use crate::model::types::MsgType;
 use chrono::Utc;
-use deribit_base::{impl_json_debug_pretty, impl_json_display};
 use serde::{Deserialize, Serialize};
 
 /// Order Mass Cancel Request message (MsgType = 'q')

--- a/src/message/orders/mass_status.rs
+++ b/src/message/orders/mass_status.rs
@@ -11,7 +11,6 @@ use crate::error::{DeribitFixError, Result as DeribitFixResult};
 use crate::message::builder::MessageBuilder;
 use crate::model::types::MsgType;
 use chrono::Utc;
-use deribit_base::{impl_json_debug_pretty, impl_json_display};
 use serde::{Deserialize, Serialize};
 
 /// Order Mass Status Request message (MsgType = 'AF')

--- a/src/message/orders/new_order.rs
+++ b/src/message/orders/new_order.rs
@@ -11,7 +11,6 @@ use crate::error::Result as DeribitFixResult;
 use crate::message::builder::MessageBuilder;
 use crate::model::types::MsgType;
 use chrono::{DateTime, Utc};
-use deribit_base::{impl_json_debug_pretty, impl_json_display};
 use serde::{Deserialize, Serialize};
 
 /// New Order Single message (MsgType = 'D')

--- a/src/message/quotes/mass_quote.rs
+++ b/src/message/quotes/mass_quote.rs
@@ -11,7 +11,6 @@ use crate::message::builder::MessageBuilder;
 use crate::message::orders::{OrderSide, TimeInForce};
 use crate::model::types::MsgType;
 use chrono::{DateTime, Utc};
-use deribit_base::{impl_json_debug_pretty, impl_json_display};
 use serde::{Deserialize, Serialize};
 
 /// Quote entry for mass quote

--- a/src/message/quotes/mass_quote_acknowledgement.rs
+++ b/src/message/quotes/mass_quote_acknowledgement.rs
@@ -11,7 +11,6 @@ use crate::message::builder::MessageBuilder;
 use crate::message::orders::OrderSide;
 use crate::model::types::MsgType;
 use chrono::Utc;
-use deribit_base::{impl_json_debug_pretty, impl_json_display};
 use serde::{Deserialize, Serialize};
 
 /// Quote acknowledgement status enumeration

--- a/src/message/quotes/quote_cancel.rs
+++ b/src/message/quotes/quote_cancel.rs
@@ -11,7 +11,6 @@ use crate::message::builder::MessageBuilder;
 use crate::message::orders::OrderSide;
 use crate::model::types::MsgType;
 use chrono::Utc;
-use deribit_base::{impl_json_debug_pretty, impl_json_display};
 use serde::{Deserialize, Serialize};
 
 /// Quote cancel type enumeration

--- a/src/message/quotes/quote_request.rs
+++ b/src/message/quotes/quote_request.rs
@@ -11,7 +11,6 @@ use crate::message::builder::MessageBuilder;
 use crate::message::orders::{OrderSide, TimeInForce};
 use crate::model::types::MsgType;
 use chrono::{DateTime, Utc};
-use deribit_base::{impl_json_debug_pretty, impl_json_display};
 use serde::{Deserialize, Serialize};
 
 /// Quote type enumeration

--- a/src/message/quotes/quote_request_reject.rs
+++ b/src/message/quotes/quote_request_reject.rs
@@ -10,7 +10,6 @@ use crate::error::Result as DeribitFixResult;
 use crate::message::builder::MessageBuilder;
 use crate::model::types::MsgType;
 use chrono::Utc;
-use deribit_base::{impl_json_debug_pretty, impl_json_display};
 use serde::{Deserialize, Serialize};
 
 /// Quote request reject reason enumeration

--- a/src/message/quotes/quote_status_report.rs
+++ b/src/message/quotes/quote_status_report.rs
@@ -11,7 +11,6 @@ use crate::message::builder::MessageBuilder;
 use crate::message::orders::OrderSide;
 use crate::model::types::MsgType;
 use chrono::{DateTime, Utc};
-use deribit_base::{impl_json_debug_pretty, impl_json_display};
 use serde::{Deserialize, Serialize};
 
 /// Quote status enumeration

--- a/src/message/quotes/rfq_request.rs
+++ b/src/message/quotes/rfq_request.rs
@@ -11,7 +11,6 @@ use crate::message::builder::MessageBuilder;
 use crate::message::orders::{OrderSide, TimeInForce};
 use crate::model::types::MsgType;
 use chrono::{DateTime, Utc};
-use deribit_base::{impl_json_debug_pretty, impl_json_display};
 use serde::{Deserialize, Serialize};
 
 /// RFQ request type enumeration

--- a/src/message/risk/mm_protection_limits.rs
+++ b/src/message/risk/mm_protection_limits.rs
@@ -10,7 +10,6 @@ use crate::error::Result as DeribitFixResult;
 use crate::message::builder::MessageBuilder;
 use crate::model::types::MsgType;
 use chrono::{DateTime, Utc};
-use deribit_base::{impl_json_debug_pretty, impl_json_display};
 use serde::{Deserialize, Serialize};
 
 /// MM Protection action enumeration

--- a/src/message/risk/mm_protection_limits_result.rs
+++ b/src/message/risk/mm_protection_limits_result.rs
@@ -10,7 +10,6 @@ use crate::error::Result as DeribitFixResult;
 use crate::message::builder::MessageBuilder;
 use crate::model::types::MsgType;
 use chrono::{DateTime, Utc};
-use deribit_base::{impl_json_debug_pretty, impl_json_display};
 use serde::{Deserialize, Serialize};
 
 // Re-export from mm_protection_limits module

--- a/src/message/risk/mm_protection_reset.rs
+++ b/src/message/risk/mm_protection_reset.rs
@@ -10,7 +10,6 @@ use crate::error::Result as DeribitFixResult;
 use crate::message::builder::MessageBuilder;
 use crate::model::types::MsgType;
 use chrono::{DateTime, Utc};
-use deribit_base::{impl_json_debug_pretty, impl_json_display};
 use serde::{Deserialize, Serialize};
 
 // Re-export from mm_protection_limits module

--- a/src/message/trade/trade_capture_report.rs
+++ b/src/message/trade/trade_capture_report.rs
@@ -11,7 +11,6 @@ use crate::message::builder::MessageBuilder;
 use crate::message::orders::OrderSide;
 use crate::model::types::MsgType;
 use chrono::{DateTime, Utc};
-use deribit_base::{impl_json_debug_pretty, impl_json_display};
 use serde::{Deserialize, Serialize};
 
 /// Trade capture report type enumeration

--- a/src/message/trade/trade_capture_report_request.rs
+++ b/src/message/trade/trade_capture_report_request.rs
@@ -11,7 +11,6 @@ use crate::message::builder::MessageBuilder;
 use crate::message::orders::OrderSide;
 use crate::model::types::MsgType;
 use chrono::{DateTime, Utc};
-use deribit_base::{impl_json_debug_pretty, impl_json_display};
 use serde::{Deserialize, Serialize};
 
 /// Trade capture report request type enumeration

--- a/src/message/trade/trade_capture_report_request_ack.rs
+++ b/src/message/trade/trade_capture_report_request_ack.rs
@@ -10,7 +10,6 @@ use crate::error::Result as DeribitFixResult;
 use crate::message::builder::MessageBuilder;
 use crate::model::types::MsgType;
 use chrono::Utc;
-use deribit_base::{impl_json_debug_pretty, impl_json_display};
 use serde::{Deserialize, Serialize};
 
 /// Trade capture report request result enumeration

--- a/src/message/user/user_request.rs
+++ b/src/message/user/user_request.rs
@@ -11,7 +11,6 @@ use crate::message::builder::MessageBuilder;
 use crate::model::types::MsgType;
 use base64::{Engine as _, engine::general_purpose};
 use chrono::Utc;
-use deribit_base::{impl_json_debug_pretty, impl_json_display};
 use serde::{Deserialize, Serialize};
 
 /// User request type enumeration

--- a/src/message/user/user_response.rs
+++ b/src/message/user/user_response.rs
@@ -11,7 +11,6 @@ use crate::message::builder::MessageBuilder;
 use crate::model::types::MsgType;
 use base64::{Engine as _, engine::general_purpose};
 use chrono::Utc;
-use deribit_base::{impl_json_debug_pretty, impl_json_display};
 use serde::{Deserialize, Serialize};
 
 // Re-export UserStatus from user_request module

--- a/src/model/types.rs
+++ b/src/model/types.rs
@@ -3,7 +3,6 @@
    Email: jb@taunais.com
    Date: 21/7/25
 ******************************************************************************/
-use deribit_base::{impl_json_debug_pretty, impl_json_display};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 


### PR DESCRIPTION
## Problem

`deribit-base` 0.2.6 does not export `impl_json_display` or `impl_json_debug_pretty`, causing a compilation failure across 25 files:

```
error[E0432]: unresolved imports `deribit_base::impl_json_debug_pretty`, `deribit_base::impl_json_display`
  --> src/config/base.rs:15:20
   |
15 | use deribit_base::{impl_json_debug_pretty, impl_json_display};
   |                    ^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^
   |                    no `impl_json_debug_pretty` in the root
   |                    no `impl_json_display` in the root
```

## Fix

- Add `src/macros.rs` defining both macros locally:
  - `impl_json_display!` — implements `std::fmt::Display` via `serde_json::to_string`
  - `impl_json_debug_pretty!` — implements `std::fmt::Debug` via `serde_json::to_string_pretty`
- Load them with `#[macro_use] mod macros;` in `lib.rs`
- Remove the broken `use deribit_base::{...}` imports from all 25 affected files

## Testing

All 242 unit tests pass after this change:

```
test result: ok. 242 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```